### PR TITLE
Add functionality to rename decks

### DIFF
--- a/e2e/decks.spec.ts
+++ b/e2e/decks.spec.ts
@@ -93,3 +93,16 @@ test('should be able to publish a deck', async ({ page }) => {
         await page.locator('[data-testid="toggle"]').isChecked(),
     ).toBeTruthy();
 });
+
+test('should allow renaming a deck', async ({ page }) => {
+    await logInAsUserN(5)({ page });
+    await page.goto('http://localhost:3000/decks');
+    await page.click('text=My new deck');
+    await expect(page).toHaveURL(
+        /http:\/\/localhost:3000\/decks\/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/,
+    );
+    await page.click('text=Rename');
+    await page.fill('input[name="newDeckName"]', 'My renamed deck');
+    await page.click('text=Save');
+    await expect(page.locator('h3')).toHaveText('My renamed deck');
+});

--- a/src/app/(logged-in)/decks/[id]/page.tsx
+++ b/src/app/(logged-in)/decks/[id]/page.tsx
@@ -6,6 +6,7 @@ import ContextMenuIconWrapper from '@/app/_components/client-side/ContextMenu/Co
 import FlashcardEditorGrid from '@/app/_components/client-side/FlashcardEditorGrid';
 import { HelpTooltip } from '@/app/_components/HelpTooltip';
 import Panel from '@/app/_components/Panel';
+import RenameDeckDialog from '@/app/_components/client-side/RenameDeckDialog';
 import { Database } from '@/app/_lib/database.types';
 import { Deck as DeckType, Flashcard } from '@/app/_lib/types';
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline';
@@ -23,6 +24,7 @@ const supabase = createBrowserClient<Database>(
 
 const Deck = ({ params: { id } }: { params: { id: string } }) => {
     const [user, setUser] = useState<User | null>(null);
+    const [showRenameDialog, setShowRenameDialog] = useState(false);
 
     useEffect(() => {
         const fetchUser = async () => {
@@ -60,6 +62,11 @@ const Deck = ({ params: { id } }: { params: { id: string } }) => {
         [],
     );
 
+    const handleRenameDeck = async (newName: string) => {
+        await deck[0].atomicPatch({ name: newName });
+        setShowRenameDialog(false);
+    };
+
     if (!deckCards || !deckCards) {
         return <div>Deck not found</div>;
     }
@@ -78,6 +85,7 @@ const Deck = ({ params: { id } }: { params: { id: string } }) => {
                             <Button
                                 intent="iconButton"
                                 className="ml-2 text-stone-600"
+                                onClick={() => setShowRenameDialog(true)}
                             >
                                 <PencilSquareIcon className="h-6 w-6" />
                             </Button>
@@ -114,6 +122,12 @@ const Deck = ({ params: { id } }: { params: { id: string } }) => {
                     />
                 </div>
             </Panel>
+
+            <RenameDeckDialog
+                isOpen={showRenameDialog}
+                onClose={() => setShowRenameDialog(false)}
+                onSave={handleRenameDeck}
+            />
 
             <FlashcardEditorGrid cards={deckCards} deckId={id} />
         </>

--- a/src/app/_components/client-side/RenameDeckDialog.tsx
+++ b/src/app/_components/client-side/RenameDeckDialog.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Button from '../Button';
+import Dialog from './Dialog';
+import Input from './Input';
+
+type RenameDeckDialogProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    onSave: (newName: string) => void;
+};
+
+const RenameDeckDialog: React.FC<RenameDeckDialogProps> = ({
+    isOpen,
+    onClose,
+    onSave,
+}: RenameDeckDialogProps) => {
+    let newName = '';
+
+    const handleSave = () => {
+        onSave(newName);
+    };
+
+    return (
+        <Dialog isOpen={isOpen} onClose={onClose}>
+            <div className="flex flex-col items-center justify-center p-4">
+                <h3 className="mb-4 text-lg font-semibold">Rename Deck</h3>
+                <Input
+                    id="newDeckName"
+                    placeholder="New deck name"
+                    onChange={(e) => (newName = e.target.value)}
+                />
+                <div className="mt-4 flex w-full justify-end gap-2">
+                    <Button intent="basic" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button intent="primary" onClick={handleSave}>
+                        Save
+                    </Button>
+                </div>
+            </div>
+        </Dialog>
+    );
+};
+
+export default RenameDeckDialog;


### PR DESCRIPTION
This pull request introduces the functionality to rename decks within the application, enhancing user experience by allowing more dynamic interaction with deck management.

- **New Component**: Adds `RenameDeckDialog.tsx` in `src/app/_components/client-side`, implementing a modal dialog with an input field for entering a new deck name and a save button to confirm the change.
- **Deck Page Update**: Modifies `src/app/(logged-in)/decks/[id]/page.tsx` to include the `RenameDeckDialog` component, enabling the modal to be opened via a button next to the deck name. Implements the logic to update the deck's name in the database upon saving.
- **E2E Testing**: Updates `e2e/decks.spec.ts` to include a test case for the deck renaming functionality, ensuring the feature works as expected from an end-to-end perspective.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nukeop/flashcards?shareId=11059076-b045-47b6-b158-e1ef492b09c7).